### PR TITLE
config: `SocketAddr::set_reuse_port` on Unix

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -61,6 +61,7 @@ impl Async<TcpListener> {
         )?;
         socket.set_nonblocking(true)?;
         socket.set_reuse_address(true)?;
+        #[cfg(unix)]
         socket.set_reuse_port(true)?;
         socket.set_nodelay(true)?;
         socket.bind(&address.into())?;


### PR DESCRIPTION
Fix the problem that window cannot be compiled
